### PR TITLE
Fixed bug in number of bsub scripts to create

### DIFF
--- a/macrotools/macrotools.py
+++ b/macrotools/macrotools.py
@@ -47,7 +47,7 @@ def bSubSplitJobs(pyScriptName, dataOrMC, inputFile, numberOfJobs):
 	clearBsubShellScripts()
 	nJobs = splitJobsForBsub(dataOrMC, inputFile, numberOfJobs)
 	print "Prepared %i jobs ready to be submitted to bsub." % nJobs
-	for i in range (1, numberOfJobs+1):
+	for i in range (1, nJobs+1):
 		splitListFile="split_%i_%s" % (i , inputFile)
 		pyCommand = "python " + pyScriptName + " splitLists/" + splitListFile + " " + "output/" + pyScriptName + "-output_%i-" %i + inputFile + ".root"
 		if dataOrMC == "mc":


### PR DESCRIPTION
Using numberOfJobs in the for loop for making the bsub shell scripts means that even if the file chunking results in fewer than the number of requested jobs, you will still create numberOfJobs bsub scripts, resulting in a mismatch between the number of files in the splitLists folder and submission scripts in the bsubs folder
